### PR TITLE
Adding kinopoisk.ru/series support

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
             var yohoho = document.querySelector('#yohoho');
             if (title && title.value && yohoho) {
                 if (/kinopoisk\.ru/i.test(title.value)) {
-                    var exec = /(film\/|movie\/).*?([0-9]{3,7})\//gi.exec(title.value);
+                    var exec = /(film\/|movie\/|series\/).*?([0-9]{3,7})\//gi.exec(title.value);
                     if (exec && exec[2]) {
                         yohoho.dataset.kinopoisk = exec[2];
                         if (window.location.hostname === 'yohoho.cc') {


### PR DESCRIPTION
Currently Yohoho can’t automatically get TV series ID from Kinopoisk. There are no movies with the same ID any series has and kinopoisk.ru/film/SERIESID is redirecting to kinopoisk.ru/series/SERIESID.
Also there shouldn’t be any issues with merging with bitbucket repo.