### PR TITLE
Performance fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,29 +96,70 @@
     });
 </script>
 <script>
-    document.addEventListener('DOMContentLoaded', function () {
-        var seo = document.querySelector('.index-seo').innerText;
-        var items = seo.split(' ');
+    var UPDATE_TIME = 100;
 
-        (function flashWord() {
-            var i = 0;
-            function run(item) {
-                var t = setTimeout(function () {
-                    clearTimeout(t);
-                    document.querySelector('.index-seo').innerHTML = seo.replace(new RegExp(' ' + item + ' ', 'g'), ' <span style="color: #fff">' + item + '</span> ');
-                    if (items.length) {
-                        i = getRandom(0, items.length - 1);
-                        run(items[i].replace(/[^A-Za-zА-Яа-яёЁ0-9]/gim, ''));
-                    }
-                }, 100);
+    function getRandom(min, max) {
+        min = Math.ceil(min);
+        max = Math.floor(max);
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    function run(prevNodes, map) {
+        var t = setTimeout(function() {
+            clearTimeout(t);
+            var nodes = map[getRandom(0, Math.floor(map.length / 2))]
+            prevNodes.forEach(node => {
+                node.style.color = 'inherit';
+            });
+
+            nodes.forEach(node => {
+                node.style.color = '#fff';
+            });
+
+            run(nodes, map);
+        }, UPDATE_TIME);
+    }
+
+    function flashWord() {
+        var seoElement = document.querySelector('.index-seo');
+        var seoText = seoElement.innerText;
+        var items = seoText.split(' ');
+
+        function getRandom(min, max) {
+            min = Math.ceil(min);
+            max = Math.floor(max);
+
+            return Math.floor(Math.random() * (max - min + 1)) + min;
+        }
+
+        var uniqItems = items.reduce((uniq, item) => {
+            if (!uniq.item) {
+                uniq[item] = `_${Math.random().toString().slice(2, 10)}`
             }
-            function getRandom(min, max) {
-                min = Math.ceil(min);
-                max = Math.floor(max);
-                return Math.floor(Math.random() * (max - min + 1)) + min;
+            return uniq;
+        }, {});
+
+        seoElement.innerHTML =  Object.entries(uniqItems).reduce((total, [word, className]) => {
+            var cleanWord = word.replace(new RegExp(`[^A-Za-zА-Яа-яёЁ0-9]`, 'gim'));
+            if (word !== cleanWord) {
+                return total;
             }
-            run(items[i]);
-        })();
+
+            return total.replace(new RegExp(` ${cleanWord} `, 'g'), ` <span class="${className}">${cleanWord}</span> `);;
+        }, seoText);
+
+        var nodesMap = Object.values(uniqItems)
+            .map(className =>
+                Array.from(document.querySelectorAll(`.${className}`)),
+            {})
+            .filter(nodes => nodes.length)
+            .sort((a, b) => b.length - a.length);
+
+        run([], nodesMap);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        flashWord();
 
         (function countMovies() {
             var date = new Date();

--- a/index.html
+++ b/index.html
@@ -125,33 +125,25 @@
         var seoText = seoElement.innerText;
         var items = seoText.split(' ');
 
-        function getRandom(min, max) {
-            min = Math.ceil(min);
-            max = Math.floor(max);
-
-            return Math.floor(Math.random() * (max - min + 1)) + min;
-        }
-
         var uniqItems = items.reduce((uniq, item) => {
-            if (!uniq.item) {
+            if (!uniq[item]) {
                 uniq[item] = `_${Math.random().toString().slice(2, 10)}`
             }
             return uniq;
         }, {});
 
         seoElement.innerHTML =  Object.entries(uniqItems).reduce((total, [word, className]) => {
-            var cleanWord = word.replace(new RegExp(`[^A-Za-zА-Яа-яёЁ0-9]`, 'gim'));
+            var cleanWord = word.replace(/[^A-Za-zА-Яа-яёЁ0-9]/gim);
             if (word !== cleanWord) {
                 return total;
             }
 
-            return total.replace(new RegExp(` ${cleanWord} `, 'g'), ` <span class="${className}">${cleanWord}</span> `);;
+            return total.replace(new RegExp(` ${cleanWord} `, 'g'),
+                ` <span class="${className}">${cleanWord}</span> `);
         }, seoText);
 
         var nodesMap = Object.values(uniqItems)
-            .map(className =>
-                Array.from(document.querySelectorAll(`.${className}`)),
-            {})
+            .map(className => Array.from(document.querySelectorAll(`.${className}`)), {})
             .filter(nodes => nodes.length)
             .sort((a, b) => b.length - a.length);
 


### PR DESCRIPTION
**Проблема**
Пользуясь страницей обнаружил что она сильно просаживет производительность.

**Решение**
Оптимизировать скрипт flashWord.

**Результаты**
Frame Rate на CPU 6x Slowdown throttle на **старом коде**
![2022-04-15 20 45 46](https://user-images.githubusercontent.com/4532214/163603628-970aad77-1d40-42f1-a490-b6da49cbc447.jpg)

Frame Rate на CPU 6x Slowdown throttle на **новом коде**
![2022-04-15 20 45 51](https://user-images.githubusercontent.com/4532214/163603785-1f51f9a8-15e1-4f1a-b364-fa0b3f5faa45.jpg)

Замер производительности во вкладке Performance Monitor
![2022-04-15 20 47 40](https://user-images.githubusercontent.com/4532214/163603933-932a171d-2b40-43bf-a519-542313d27a19.jpg)
Стрелкой указана точка перезагрузки страницы с новым кодом.

Как видно на графике, использование CPU снизилось c ~30-50% до ~3-10%

**Что было сделано**
Вместо текущей логики скрипта который в реалтайме регулярным выражением искал слова и заменял все **содержимое** innerHtml элемента `.index-seo`, принял решение сначала выделить все уникальные слова, обернуть их в уникальный className и составить ассоциативный словарь для быстрого доступа к этим элементам.

Далее принцип тот же, в бесконечном цикле получаем ссылку на уже готовый список нод с одинаковыми словами и меняем им только свойство style. Это позволяет браузеру не перерисовывать весь элемент, а только те ноды стили которых меняются.

Пример paint flashing как было до:
<img width="899" alt="image" src="https://user-images.githubusercontent.com/4532214/163604574-ca7f5e78-c801-47f2-8d2b-622c2ce9b574.png">

Пример paint flashing как стало после:
<img width="903" alt="image" src="https://user-images.githubusercontent.com/4532214/163604611-603ea7a9-f902-4ec5-a56e-802ea82dfbd2.png">



